### PR TITLE
Stop using api client exported from app-common

### DIFF
--- a/src/components/molecules/Sample.tsx
+++ b/src/components/molecules/Sample.tsx
@@ -1,9 +1,4 @@
-import { useAuth0 } from "@auth0/auth0-react";
-import { databaseStore } from "@dataware-tools/app-common";
 import Button from "@mui/material/Button";
-import useSWR, { mutate } from "swr";
-
-const apiUrlBase = process.env.NEXT_PUBLIC_BACKEND_API_PREFIX || "/api/latest";
 
 export type SamplePresentationProps = {
   user: any;
@@ -31,22 +26,16 @@ export const SamplePresentation = ({
 };
 
 export const Sample = (): JSX.Element => {
-  const { user, getAccessTokenSilently } = useAuth0();
-  const fetchAPI = async () => {
-    databaseStore.OpenAPI.TOKEN = await getAccessTokenSilently();
-    databaseStore.OpenAPI.BASE = apiUrlBase;
-    const Res = await databaseStore.DatabaseService.listDatabases({});
-    return Res;
-  };
-  const URL = `${apiUrlBase}/databases`;
-  const { data, error } = useSWR(URL, fetchAPI);
+  const data = "this is sample";
+  const error = undefined;
+  const user = { name: "sample" };
 
   return (
     <SamplePresentation
       user={user}
       data={data}
       error={error}
-      onClick={() => mutate(URL)}
+      onClick={() => console.log("test")}
     />
   );
 };


### PR DESCRIPTION
## What?
Stop using api client exported from app-common

## Why?
app-common から API client をエクスポートしないようにするため

## See also
Related dataware-tools/dataware-tools#92