### PR TITLE
Fix supporting engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.0",
   "basePath": "/launcher/",
   "engines": {
-    "node": "16.13.1",
-    "npm": "8.x"
+    "node": "14 - 16",
+    "npm": "7 - 8"
   },
   "volta": {
     "node": "16.13.1"


### PR DESCRIPTION
## What?
Fix supporting engines

## Why?
dependabot が npmv7 と node 14 を使っているので