### PR TITLE
Switch application card appearance depends on apps.json

### DIFF
--- a/public/apps.json
+++ b/public/apps.json
@@ -1,13 +1,4 @@
 {
-  "webviz": {
-    "id": "webviz",
-    "icon": "https://webviz.io/favicon.ico",
-    "name": "WebViz",
-    "description": "Modern rosbag player",
-    "url": "http://webviz.hdwlab.co.jp/",
-    "visibility": "public",
-    "location": "external"
-  },
   "docs": {
     "id": "docs",
     "icon": "menu_book",

--- a/src/components/atoms/AppCard.tsx
+++ b/src/components/atoms/AppCard.tsx
@@ -8,26 +8,32 @@ import { AppType } from "utils/types";
 export type AppCardProps = Pick<
   AppType,
   "icon" | "name" | "description" | "url"
->;
+> & { disable?: boolean };
 
 export const AppCard = ({
   icon,
   name,
   description,
   url,
+  disable,
 }: AppCardProps): JSX.Element => {
   return (
     <Card
       variant="outlined"
-      onClick={() => {
-        window.location.href = url;
-      }}
+      onClick={
+        disable
+          ? undefined
+          : () => {
+              window.location.href = url;
+            }
+      }
       sx={{
         display: "flex",
         flexDirection: "column",
         justifyContent: "center",
         alignItems: "center",
-        ":hover": { cursor: "pointer" },
+        ":hover": { cursor: disable ? undefined : "pointer" },
+        opacity: disable ? "50%" : undefined,
       }}
     >
       {icon.startsWith("http") ? (

--- a/src/components/molecules/AppCardList.tsx
+++ b/src/components/molecules/AppCardList.tsx
@@ -1,5 +1,4 @@
 import Grid from "@mui/material/Grid";
-import Box from "@mui/system/Box";
 import { AppCardProps, AppCard } from "../atoms/AppCard";
 import { AppListType } from "utils/types";
 
@@ -20,23 +19,27 @@ export const AppCardList = ({
     </Grid>
   );
   return (
-    <Box sx={{ flexGrow: 1 }}>
-      <Grid
-        container
-        columns={{ xs: 2, md: 3, lg: 4, xl: 5 }}
-        spacing={{ xs: 1, md: 2, lg: 4 }}
-      >
-        {publicOnly
-          ? Object.values(apps)
-              .filter(
-                (app) =>
-                  app.location === location && app.visibility === "public"
-              )
-              .map((app) => <GridAppCard key={app.id} app={app} />)
-          : Object.values(apps)
-              .filter((app) => app.location === location)
-              .map((app) => <GridAppCard key={app.id} app={app} />)}
-      </Grid>
-    </Box>
+    <Grid
+      container
+      columns={{ xs: 2, md: 3, lg: 4, xl: 5 }}
+      spacing={{ xs: 1, md: 2, lg: 4 }}
+      sx={{ flexGrow: 1, width: "100%" }}
+    >
+      {publicOnly
+        ? Object.values(apps)
+            .filter((app) => app.location === location)
+            .map((app) => (
+              <GridAppCard
+                key={app.id}
+                app={{
+                  ...app,
+                  disable: app.visibility !== "public",
+                }}
+              />
+            ))
+        : Object.values(apps)
+            .filter((app) => app.location === location)
+            .map((app) => <GridAppCard key={app.id} app={app} />)}
+    </Grid>
   );
 };

--- a/src/pages/IndexPage.tsx
+++ b/src/pages/IndexPage.tsx
@@ -30,6 +30,9 @@ export const IndexPagePresentation = ({
       <NoticeableLetters>{children}</NoticeableLetters>
     </Typography>
   );
+  const isExistExternalApps = apps
+    ? Object.values(apps).some((app) => app.location === "external")
+    : false;
 
   return (
     <PageContainer>
@@ -42,22 +45,28 @@ export const IndexPagePresentation = ({
                   Please login to see all of the available tools.
                 </Typography>
               )}
-              <Title>Internal tools</Title>
+              <Title>
+                {isExistExternalApps ? "Internal tools" : "Contents"}
+              </Title>
               <AppCardList
                 apps={apps}
                 location="internal"
                 publicOnly={!isAuthenticated}
               />
-              <Divider
-                variant="middle"
-                sx={{ paddingTop: 1, paddingBottom: 1 }}
-              />
-              <Title>External tools</Title>
-              <AppCardList
-                apps={apps}
-                location="external"
-                publicOnly={!isAuthenticated}
-              />
+              {isExistExternalApps ? (
+                <>
+                  <Divider
+                    variant="middle"
+                    sx={{ paddingTop: 1, paddingBottom: 1 }}
+                  />
+                  <Title>External tools</Title>
+                  <AppCardList
+                    apps={apps}
+                    location="external"
+                    publicOnly={!isAuthenticated}
+                  />
+                </>
+              ) : null}
             </>
           )}
         </PageMain>

--- a/src/pages/IndexPage.tsx
+++ b/src/pages/IndexPage.tsx
@@ -42,7 +42,7 @@ export const IndexPagePresentation = ({
             <>
               {!isAuthenticated && (
                 <Typography variant="caption">
-                  Please login to see all of the available tools.
+                  Please login to use all of the available tools.
                 </Typography>
               )}
               <Title>


### PR DESCRIPTION
## What?
Switch application appearance depends on apps.json

## Why?
- External tools が無い場合にはその部分を完全に非表示にした方が画面がシンプルになるので
- ログインすることで使えるようになるアプリも薄く表示されてる方が親切なので

## Screenshots
External tools なし ＆ 未ログイン
![image](https://user-images.githubusercontent.com/72174933/151286349-69a956e5-71e9-4a78-91c9-c13a47d990d6.png)

External tools なし ＆ ログイン済み
![image](https://user-images.githubusercontent.com/72174933/151286300-1b8f709f-c82c-49a1-9730-b57a31276e48.png)

External tools あり ＆ 未ログイン
![image](https://user-images.githubusercontent.com/72174933/151286446-780afb98-f1fd-4965-b988-dc2bebc3e118.png)

External tools あり ＆ ログイン済み
![image](https://user-images.githubusercontent.com/72174933/151286501-7ca6c4ad-c6a5-4715-a010-f827d2d6707f.png)
