### PR TITLE
Skip deploy ci on renovate's PR

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -6,7 +6,7 @@ jobs:
   hook:
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    if: github.actor != 'dependabot[bot]'
+    if: github.actor != 'renovate-bot'
     steps:
       - name: Repository Dispatch
         uses: peter-evans/repository-dispatch@v1


### PR DESCRIPTION
## What?
Skip deploy ci on renovate's PR

## Why?
依存関係の自動更新ではデプロイする必要がないから