### PR TITLE
Skip deploy ci on renovate's PR

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -6,7 +6,7 @@ jobs:
   hook:
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    if: github.actor != 'renovate-bot'
+    if: ! startsWith(github.ref_name,'renovate/')
     steps:
       - name: Repository Dispatch
         uses: peter-evans/repository-dispatch@v1


### PR DESCRIPTION
## What?
Skip deploy ci on renovate's PR

## Why?
github.actor ではうまいことスキップできなかったから