### PR TITLE
Use shared toast component of app-common instead of raw toast

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,6 @@
         "react": "17.0.2",
         "react-dom": "17.0.2",
         "react-router-dom": "6.3.0",
-        "react-toastify": "8.2.0",
         "serve": "14.0.1",
         "swr": "1.3.0"
       },
@@ -27694,6 +27693,7 @@
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-8.2.0.tgz",
       "integrity": "sha512-Pg2Ju7NngAamarFvLwqrFomJ57u/Ay6i6zfLurt/qPynWkAkOthu6vxfqYpJCyNhHRhR4hu7+bySSeWWJu6PAg==",
+      "peer": true,
       "dependencies": {
         "clsx": "^1.1.1"
       },
@@ -55707,6 +55707,7 @@
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-8.2.0.tgz",
       "integrity": "sha512-Pg2Ju7NngAamarFvLwqrFomJ57u/Ay6i6zfLurt/qPynWkAkOthu6vxfqYpJCyNhHRhR4hu7+bySSeWWJu6PAg==",
+      "peer": true,
       "requires": {
         "clsx": "^1.1.1"
       }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "react-router-dom": "6.3.0",
-    "react-toastify": "8.2.0",
     "serve": "14.0.1",
     "swr": "1.3.0"
   },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,11 @@
 import "./scrollbar.global.css";
-import { theme } from "@dataware-tools/app-common";
+import { theme, Toaster } from "@dataware-tools/app-common";
 import CssBaseline from "@mui/material/CssBaseline";
 import { ThemeProvider } from "@mui/material/styles";
 import { StylesProvider } from "@mui/styles";
 import { SWRConfig } from "swr";
 import Router from "./Router";
 import { SwrOptions } from "./utils/index";
-import "react-toastify/dist/ReactToastify.css";
 
 const App = () => {
   return (
@@ -14,6 +13,7 @@ const App = () => {
       <StylesProvider injectFirst>
         <ThemeProvider theme={theme}>
           <CssBaseline />
+          <Toaster />
           <Router />
         </ThemeProvider>
       </StylesProvider>

--- a/src/pages/IndexPage.tsx
+++ b/src/pages/IndexPage.tsx
@@ -4,11 +4,11 @@ import {
   PageBody,
   PageContainer,
   PageMain,
+  enqueueErrorToastForFetchError,
 } from "@dataware-tools/app-common";
 import { Typography } from "@mui/material";
 import Divider from "@mui/material/Divider";
 import { useEffect } from "react";
-import { toast } from "react-toastify";
 import useSWR from "swr";
 import packageInfo from "../../package.json";
 import {
@@ -80,7 +80,7 @@ export const IndexPage = (): JSX.Element => {
   const { data: apps, error } = useSWR(packageInfo.basePath + "/apps.json");
 
   useEffect(() => {
-    error && toast(JSON.stringify(error));
+    error && enqueueErrorToastForFetchError("Fail to fetch app catalog", error);
   }, [error]);
 
   return (


### PR DESCRIPTION
## What?
Use shared toast component of app-common instead of raw toast

## Why?
トーストの挙動を統一したいから